### PR TITLE
Use pairs instead of next

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -545,7 +545,7 @@ local function Wrap(Chunk, Env, Upvalues)
 						Results = {Stk[A]()};
 					end;
 
-					for Index in next, Results do -- get return count
+					for Index in pairs(Results) do -- get return count
 						if (Index > Rets) then
 							Rets = Index;
 						end;


### PR DESCRIPTION
Besides this just being more idiomatic Lua, it's actually something that gets optimized in the new VM compiler, so it's substantially faster